### PR TITLE
Adding pre & post-processing to ConversationalPipeline

### DIFF
--- a/tests/unit/test_transformers_utils.py
+++ b/tests/unit/test_transformers_utils.py
@@ -133,7 +133,6 @@ def test_wrap_conversation_pipeline():
         model="microsoft/DialoGPT-small",
         tokenizer="microsoft/DialoGPT-small",
         framework="pt",
-        device=0,
     )
     conv_pipe = wrap_conversation_pipeline(init_pipeline)
     data = {


### PR DESCRIPTION
# What does this PR do? 

This PR adds a wrapper for the `ConversationalPipeline` to increase the UX and usage of the pipeline. This was pointed out by @AbstractVoid at the `transformers` repository. https://github.com/aws/sagemaker-huggingface-inference-toolkit/issues/20#issuecomment-883152839
This PR adds his implementation for using `conversational` with `JSON`. Example

```python
predictor.predict({
     'inputs': {
            "past_user_inputs": ["Which movie is the best ?"],
            "generated_responses": ["It's Die Hard for sure."],
            "text": "Can you explain why ?",
        }
})
```

cc @vdantu for review