### PR TITLE
Auto mapping for csv

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
+++ b/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
@@ -41,8 +41,28 @@ def decode_csv(string_like):  # type: (str) -> np.array
     Returns:
         (dict): dictonatry for input
     """
+    # detects if the incoming csv has headers
+    sniffer = csv.Sniffer()
+    has_header = sniffer.has_header(string_like)
+
+    # reads csv as io
     stream = StringIO(string_like)
-    request_list = list(csv.DictReader(stream))
+
+    if has_header:
+        # reads stream as dict if it has header
+        request_list = list(csv.DictReader(stream))
+    else:
+        # identifies the number of column and either maps "inputs" or "question, context" as header
+        delimiter = sniffer.sniff(string_like).delimiter
+        col_num = len(string_like.splitlines()[0].split(delimiter))
+        if col_num == 1:
+            col_header = ["inputs"]
+        elif col_num == 2:
+            col_header = ["question", "context"]
+        else:
+            raise ValueError(f"Csv without header and more than columns cannot be decoded")
+        request_list = list(csv.DictReader(stream, fieldnames=col_header))
+
     if "inputs" in request_list[0].keys():
         return {"inputs": [entry["inputs"] for entry in request_list]}
     else:

--- a/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
+++ b/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
@@ -42,9 +42,10 @@ def decode_csv(string_like):  # type: (str) -> np.array
         (dict): dictonatry for input
     """
     # detects if the incoming csv has headers
-    sniffer = csv.Sniffer()
-    has_header = sniffer.has_header(string_like)
-
+    if any(header in string_like.splitlines()[0].lower() for header in ["question", "context", "inputs"]):
+        has_header = True
+    else:
+        has_header = False
     # reads csv as io
     stream = StringIO(string_like)
 
@@ -53,8 +54,12 @@ def decode_csv(string_like):  # type: (str) -> np.array
         request_list = list(csv.DictReader(stream))
     else:
         # identifies the number of column and either maps "inputs" or "question, context" as header
+        sniffer = csv.Sniffer()
         delimiter = sniffer.sniff(string_like).delimiter
-        col_num = len(string_like.splitlines()[0].split(delimiter))
+        if delimiter == " ":
+            col_num = 1
+        else:
+            col_num = len(string_like.splitlines()[0].split(delimiter))
         if col_num == 1:
             col_header = ["inputs"]
         elif col_num == 2:

--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -134,7 +134,6 @@ class HuggingFaceHandlerService(ABC):
             )
 
         decoded_input_data = decoder_encoder.decode(input_data, content_type)
-        print("data", decoded_input_data)
         return decoded_input_data
 
     def predict(self, data, model):

--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -134,6 +134,7 @@ class HuggingFaceHandlerService(ABC):
             )
 
         decoded_input_data = decoder_encoder.decode(input_data, content_type)
+        print("data", decoded_input_data)
         return decoded_input_data
 
     def predict(self, data, model):

--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -46,6 +46,21 @@ def test_decode_csv():
     assert decoded_data == {"inputs": ["I love you", "I like you"]}
 
 
+def test_decode_csv_without_header():
+    decoded_data = decoder_encoder.decode_csv(
+        "where do i live?,My name is Philipp and I live in Nuremberg\r\nwhere is Berlin?,Berlin is the capital of Germany"
+    )
+    assert decoded_data == {
+        "inputs": [
+            {"question": "where do i live?", "context": "My name is Philipp and I live in Nuremberg"},
+            {"question": "where is Berlin?", "context": "Berlin is the capital of Germany"},
+        ]
+    }
+    text_classification_input = "inputs\r\nI love you\r\nI like you"
+    decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
+    assert decoded_data == {"inputs": ["I love you", "I like you"]}
+
+
 def test_encode_json():
     encoded_data = decoder_encoder.encode_json(ENCODE_JSON_INPUT)
     assert json.loads(encoded_data) == ENCODE_JSON_INPUT

--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -42,7 +42,7 @@ def test_decode_csv():
         ]
     }
     text_classification_input = "inputs\r\nI love you\r\nI like you"
-    decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
+    decoded_data = decoder_encoder.decode_csv(text_classification_input)
     assert decoded_data == {"inputs": ["I love you", "I like you"]}
 
 
@@ -56,9 +56,21 @@ def test_decode_csv_without_header():
             {"question": "where is Berlin?", "context": "Berlin is the capital of Germany"},
         ]
     }
-    text_classification_input = "inputs\r\nI love you\r\nI like you"
-    decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
-    assert decoded_data == {"inputs": ["I love you", "I like you"]}
+    text_classification_input = """@VirginAmerica What @dhepburn said.                                                                                                                           
+@VirginAmerica plus you've added commercials to the experience... tacky.                                                                                      
+@VirginAmerica I didn't today... Must mean I need to take another trip!                                                                                       
+@VirginAmerica it's really aggressive to blast obnoxious "entertainment" in your guests' faces &amp; they have little recourse                                
+@VirginAmerica and it's a really big bad thing about it                                                                                                       
+@VirginAmerica seriously would pay $30 a flight for seats that didn't have this playing.
+it's really the only bad thing about flying VA                       
+@VirginAmerica yes, nearly every time I fly VX this “ear worm” won’t go away :)                                                                               
+@VirginAmerica Really missed a prime opportunity for Men Without Hats parody, there. https://t.co/mWpG7grEZP                                                  
+@virginamerica Well, I didn't…but NOW I DO! :-D                                                                                                               
+@VirginAmerica it was amazing, and arrived an hour early. You're too good to me.                                                                              
+@VirginAmerica did you know that suicide is the second leading cause of death among teens 10-24"""
+    decoded_data = decoder_encoder.decode_csv(text_classification_input)
+    assert "inputs" in decoded_data
+    assert isinstance(decoded_data["inputs"], list)
 
 
 def test_encode_json():


### PR DESCRIPTION
# What does this PR do? 

This PR adds an automatic column assigned when a CSV without a header is provided, e.g. batch transform. Currently, it checks if the first line contains either `inputs`, `question` or `context` since these are the possible header we can have. If there is none of these it assumes that the CSV has no headers. 
If it has no header and 1 col it parses the 1 col as `inputs` if it has 2 cols the first col is the `question` and the second the `context`. 

cc @vdantu 