### PR TITLE
Add exception for CSV without headers. 

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
+++ b/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
@@ -47,7 +47,7 @@ def decode_csv(string_like):  # type: (str) -> np.array
     # detects if the incoming csv has headers
     if not any(header in string_like.splitlines()[0].lower() for header in ["question", "context", "inputs"]):
         raise PredictionException(
-            f"You need to provide as CSV with Header columns to use it with the inference toolkit default handler.",
+            f"You need to provide the correct CSV with Header columns to use it with the inference toolkit default handler.",
             400,
         )
     # reads csv as io

--- a/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
+++ b/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
@@ -16,6 +16,8 @@ import json
 from io import StringIO
 import csv
 import numpy as np
+from mms.service import PredictionException
+
 from sagemaker_inference.decoder import (
     _npy_to_numpy,
     _npz_to_sparse,
@@ -42,6 +44,13 @@ def decode_csv(string_like):  # type: (str) -> np.array
         (dict): dictonatry for input
     """
     stream = StringIO(string_like)
+    # detects if the incoming csv has headers
+    if not any(header in string_like.splitlines()[0].lower() for header in ["question", "context", "inputs"]):
+        raise PredictionException(
+            f"You need to provide as CSV with Header columns to use it with the inference toolkit default handler.",
+            400,
+        )
+    # reads csv as io
     request_list = list(csv.DictReader(stream))
     if "inputs" in request_list[0].keys():
         return {"inputs": [entry["inputs"] for entry in request_list]}
@@ -123,6 +132,8 @@ def decode(content, content_type=content_types.JSON):
         return decoder(content)
     except KeyError:
         raise errors.UnsupportedFormatError(content_type)
+    except PredictionException as pred_err:
+        raise pred_err
 
 
 def encode(content, content_type=content_types.JSON):

--- a/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
+++ b/src/sagemaker_huggingface_inference_toolkit/decoder_encoder.py
@@ -11,24 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import csv
 import datetime
 import json
 from io import StringIO
-import csv
-import numpy as np
-from mms.service import PredictionException
 
-from sagemaker_inference.decoder import (
-    _npy_to_numpy,
-    _npz_to_sparse,
-)
-from sagemaker_inference.encoder import (
-    _array_to_npy,
-)
-from sagemaker_inference import (
-    content_types,
-    errors,
-)
+import numpy as np
+from sagemaker_inference import content_types, errors
+from sagemaker_inference.decoder import _npy_to_numpy, _npz_to_sparse
+from sagemaker_inference.encoder import _array_to_npy
+
+from mms.service import PredictionException
 
 
 def decode_json(content):

--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -15,15 +15,15 @@
 import importlib
 import logging
 import os
-import time
 import sys
+import time
 from abc import ABC
 
-from sagemaker_inference import environment, utils, content_types
+from sagemaker_inference import content_types, environment, utils
 from transformers.pipelines import SUPPORTED_TASKS
 
-from mms.service import PredictionException
 from mms import metrics
+from mms.service import PredictionException
 from sagemaker_huggingface_inference_toolkit import decoder_encoder
 from sagemaker_huggingface_inference_toolkit.transformers_utils import (
     _is_gpu_available,

--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+
 import pytest
-from sagemaker_huggingface_inference_toolkit import decoder_encoder
+
 from mms.service import PredictionException
+from sagemaker_huggingface_inference_toolkit import decoder_encoder
 
 
 ENCODE_JSON_INPUT = {"upper": [1425], "lower": [576], "level": [2], "datetime": ["2012-08-08 15:30"]}

--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-
+import pytest
 from sagemaker_huggingface_inference_toolkit import decoder_encoder
+from mms.service import PredictionException
 
 
 ENCODE_JSON_INPUT = {"upper": [1425], "lower": [576], "level": [2], "datetime": ["2012-08-08 15:30"]}
@@ -44,6 +45,13 @@ def test_decode_csv():
     text_classification_input = "inputs\r\nI love you\r\nI like you"
     decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
     assert decoded_data == {"inputs": ["I love you", "I like you"]}
+
+
+def test_decode_csv_without_header():
+    with pytest.raises(PredictionException):
+        decoder_encoder.decode_csv(
+            "where do i live?,My name is Philipp and I live in Nuremberg\r\nwhere is Berlin?,Berlin is the capital of Germany"
+        )
 
 
 def test_encode_json():

--- a/tests/unit/test_handler_service.py
+++ b/tests/unit/test_handler_service.py
@@ -17,13 +17,14 @@ import sys
 import tempfile
 
 import pytest
+from sagemaker_inference import content_types
 from transformers.testing_utils import require_torch, slow
 
 from mms.context import Context, RequestProcessor
 from mms.metrics.metrics_store import MetricsStore
 from sagemaker_huggingface_inference_toolkit import handler_service
 from sagemaker_huggingface_inference_toolkit.transformers_utils import _load_model_from_hub, get_pipeline
-from sagemaker_inference import content_types
+
 
 TASK = "text-classification"
 MODEL = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"


### PR DESCRIPTION
# What does this PR do? 

This PR adds an exception when a CSV is sent without or with the wrong headers. Since it is not guaranteed to parse the CSV correctly. see #24 

> **Explanation:**
> 
> When using `batch_transform` sagemaker is sending exactly 1 row as input to the endpoint, e.g.
> ```bash
> united thx off the response, finally got through the 45 min wait and talked to someone.
> ```
> The issue with this is that the `csv.sniffer` would identify the `,` as delimiter and would split this into two columns, and create an input for `question-answering` instead of `text-classification`. There is no way to identify wether the input is 1 column based or 2 column based just from 1 input, e.g. `question-answering` input
> ```bash
> the flight was delayed 45 minutes, How long was the flight delayed?
> ```
> When someone would use `MultiRecord` instead the sniffer would identify the delimiter correctly, but for me these are too many constraints and if for it to work properly. 


Tested with 
```csv
where do i live?,My Name is Philipp and I live in Nuremberg.
What is the capital?,Berlin is the capital of Germany.
```

got as response
```json
{
  "code": 400,
  "type": "InternalServerException",
  "message": "You need to provide the correct CSV with Header columns to use it with the inference toolkit default handler. : 400"
}
```

Also added a unit test for it.


