### PR TITLE
log predict time properly

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -188,7 +188,7 @@ class HuggingFaceHandlerService(ABC):
         processed_data = self.preprocess(input_data, content_type)
         preprocess_time = time.time() - start_time
         predictions = self.predict(processed_data, model)
-        predict_time = time.time() - preprocess_time
+        predict_time = time.time() - preprocess_time - start_time
         response = self.postprocess(predictions, accept)
 
         logger.info(

--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -190,11 +190,12 @@ class HuggingFaceHandlerService(ABC):
         predictions = self.predict(processed_data, model)
         predict_time = time.time() - preprocess_time - start_time
         response = self.postprocess(predictions, accept)
+        postprocess_time = time.time() - predict_time - preprocess_time - start_time
 
         logger.info(
             f"Preprocess time - {preprocess_time * 1000} ms\n"
             f"Predict time - {predict_time * 1000} ms\n"
-            f"Postprocess time - {(time.time() - predict_time) * 1000} ms"
+            f"Postprocess time - {postprocess_time * 1000} ms"
         )
 
         return response


### PR DESCRIPTION
*Description of changes:*
Calculate predict time correctly.

Handler service logs elapsed times for each component but there as below where predict time is not captured correctly.

![Screen Shot 2021-08-19 at 5 23 12 PM](https://user-images.githubusercontent.com/3424293/130277364-7aa29b13-d65d-4950-a931-6320dd83bea4.png)

With the change, the log output would be like: 
<img width="756" alt="Screen Shot 2021-08-20 at 11 24 35 AM" src="https://user-images.githubusercontent.com/3424293/130277614-15d99e7c-22a9-46ef-963d-2391b3c2281b.png">


