### PR TITLE
Fix input data used in test_decode_csv

### DIFF
--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -44,8 +44,9 @@ def test_decode_csv():
             {"question": "where is Berlin?", "context": "Berlin is the capital of Germany"},
         ]
     }
+
     text_classification_input = "inputs\r\nI love you\r\nI like you"
-    decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
+    decoded_data = decoder_encoder.decode_csv(text_classification_input)
     assert decoded_data == {"inputs": ["I love you", "I like you"]}
 
 


### PR DESCRIPTION
*Issue [#38](https://github.com/aws/sagemaker-huggingface-inference-toolkit/issues/39)*

test_decode_csv fails when I run the tests locally. Looking at
the implementation of the test I think there's an error in the input
data for the second assertion.

*Description of changes:*

This commit fixes the input data for the second assertion so that the
test passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
