### PR TITLE
Bind custom model function

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import time
+import types
 from abc import ABC
 
 from sagemaker_inference import content_types, environment, utils
@@ -264,7 +265,7 @@ class HuggingFaceHandlerService(ABC):
                 )
 
             if load_fn is not None:
-                self.load = load_fn
+                self.load = types.MethodType(load_fn, self)
             if preprocess_fn is not None:
                 self.preprocess = preprocess_fn
             if predict_fn is not None:

--- a/tests/resources/model_input_predict_output_fn/code/inference.py
+++ b/tests/resources/model_input_predict_output_fn/code/inference.py
@@ -1,5 +1,5 @@
-def model_fn(model_dir):
-    return "model"
+def model_fn(self, model_dir):
+    return self.context.model_name
 
 
 def input_fn(data, content_type):

--- a/tests/resources/model_transform_fn/code/inference_tranform_fn.py
+++ b/tests/resources/model_transform_fn/code/inference_tranform_fn.py
@@ -1,7 +1,7 @@
 import os
 
 
-def model_fn(model_dir):
+def model_fn(self, model_dir):
     return f"Loading {os.path.basename(__file__)}"
 
 

--- a/tests/unit/test_decoder_encoder.py
+++ b/tests/unit/test_decoder_encoder.py
@@ -44,8 +44,9 @@ def test_decode_csv():
             {"question": "where is Berlin?", "context": "Berlin is the capital of Germany"},
         ]
     }
+
     text_classification_input = "inputs\r\nI love you\r\nI like you"
-    decoded_data = decoder_encoder.decode_csv(DECODE_CSV_INPUT)
+    decoded_data = decoder_encoder.decode_csv(text_classification_input)
     assert decoded_data == {"inputs": ["I love you", "I like you"]}
 
 

--- a/tests/unit/test_handler_service.py
+++ b/tests/unit/test_handler_service.py
@@ -131,7 +131,7 @@ def test_postprocess(inference_handler):
 
 def test_validate_and_initialize_user_module(inference_handler):
     model_dir = os.path.join(os.getcwd(), "tests/resources/model_input_predict_output_fn")
-    CONTEXT = Context("", model_dir, {}, 1, -1, "1.1.4")
+    CONTEXT = Context("my model", model_dir, {}, 1, -1, "1.1.4")
 
     inference_handler.initialize(CONTEXT)
     CONTEXT.request_processor = [RequestProcessor({"Content-Type": "application/json"})]
@@ -140,7 +140,7 @@ def test_validate_and_initialize_user_module(inference_handler):
     prediction = inference_handler.handle([{"body": b""}], CONTEXT)
     assert "output" in prediction[0]
 
-    assert inference_handler.load({}) == "model"
+    assert inference_handler.load({}) == "my model"
     assert inference_handler.preprocess({}, "") == "data"
     assert inference_handler.predict({}, "model") == "output"
     assert inference_handler.postprocess("output", "") == "output"


### PR DESCRIPTION
*[Issue #40](https://github.com/aws/sagemaker-huggingface-inference-toolkit/issues/40)*

*Description of changes:*

This commit changes the way the custom model_fn is bound to the instance
of the HuggingFaceHandlerService so the custom model_fn has access to
the context available to the handler.

This will allow us to use that context, for example `self.device` to
ensure we properly set the device when creating a custom pipeline.

This PR also includes the fix to a failing test from https://github.com/aws/sagemaker-huggingface-inference-toolkit/pull/38.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
