### PR TITLE
Hint at correct env var name in error message

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -107,7 +107,7 @@ class HuggingFaceHandlerService(ABC):
             hf_pipeline = get_pipeline(task=task, model_dir=model_dir, device=self.device)
         else:
             raise ValueError(
-                f"You need to define one of the following {list(SUPPORTED_TASKS.keys())} as env 'TASK'.", 403
+                f"You need to define one of the following {list(SUPPORTED_TASKS.keys())} as env 'HF_TASK'.", 403
             )
         return hf_pipeline
 


### PR DESCRIPTION
*Issue #, if available:*
The name of the env var in the ValueError is incorrect

*Description of changes:*
HF_TASK instead of TASK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
