### PR TITLE
feature: Serve model directly from original model artifact directory …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ extras["test"] = [
 extras["benchmark"] = ["boto3", "locust"]
 
 extras["quality"] = [
-    "black==21.4b0",
+    "black>=21.10",
     "isort>=5.5.4",
     "flake8>=3.8.3",
 ]


### PR DESCRIPTION
…to save disk space.

*Issue #, if available:*

*Description of changes:*
Updated code and tests so that, except in HF Hub use case where the model artifact is fetched at runtime, the original model is served directly from the original model artifact location rather than calling model-archiver. This saves disk space, which matters especially for large models and in cases where the relevant disk volume did not have much space.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
