### PR TITLE
Make download/export directory configurable by env

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/mms_model_server.py
+++ b/src/sagemaker_huggingface_inference_toolkit/mms_model_server.py
@@ -45,7 +45,7 @@ logger = logging.get_logger()
 
 DEFAULT_HANDLER_SERVICE = handler_service.__name__
 
-DEFAULT_HF_HUB_MODEL_EXPORT_DIRECTORY = os.path.join(os.getcwd(), ".sagemaker/mms/models")
+DEFAULT_HF_HUB_MODEL_EXPORT_DIRECTORY = os.getenv("DEFAULT_HF_HUB_MODEL_EXPORT_DIRECTORY",os.path.join(os.getcwd(), ".sagemaker/mms/models"))
 DEFAULT_MODEL_STORE = "/"
 
 


### PR DESCRIPTION
Referring to issue #78

*Issue #, if available:* 78

*Description of changes:*
As mentioned by @philschmid, SageMaker models are currently downloaded to os.getcwd() + '...', which is usually not where EBS and other volumes are mounted - see related [discussions](https://discuss.huggingface.co/t/sagemaker-endpoint-no-space-left-on-device-with-large-models/32127/2). 

This would be a quick fix to: (1) allows configuration to any directory on SageMaker endpoint, including `/tmp` if appropriate, (2) defaults to the current setup, so it should not introduce compatibility issues with existing flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
