### PR TITLE
Add warning message to log this error.

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -60,6 +60,7 @@ class HuggingFaceHandlerService(ABC):
         self.model = None
         self.device = -1
         self.initialized = False
+        self.attempted_init = False
         self.context = None
         self.manifest = None
         self.environment = environment.Environment()
@@ -75,6 +76,7 @@ class HuggingFaceHandlerService(ABC):
         :param context: Initial context contains model server system properties.
         :return:
         """
+        self.attempted_init = True
         self.context = context
         properties = context.system_properties
         self.model_dir = properties.get("model_dir")
@@ -245,6 +247,11 @@ class HuggingFaceHandlerService(ABC):
         """
         try:
             if not self.initialized:
+                if self.attempted_init:
+                    logger.warn(
+                        "Model is not initialized, will try to load model again.\n"
+                        "Please consider increase wait time for model loading.\n"
+                    )
                 self.initialize(context)
 
             input_data = data[0].get("body")


### PR DESCRIPTION
*Issue #, if available:*

```
Customer started received 4xx error with following traceback

2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - Traceback (most recent call last):
2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - File "/opt/conda/lib/python3.10/site-packages/mms/service.py", line 108, in predict
2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - ret = self._entry_point(input_batch, self.context)
2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - File "/opt/conda/lib/python3.10/site-packages/sagemaker_huggingface_inference_toolkit/handler_service.py", line 267, in handle
2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - raise PredictionException(str(e), 400)
2024-02-29T11:07:21,222 [INFO ] W-model-2-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - mms.service.PredictionException: model_fn() takes 1 positional argument but 2 were given : 400
2024-02-29T11:07:21,315 [INFO ] W-model-4-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - Prediction error

```
*(Potential) Root cause:*

If model load failed when first time call initialize(), self.load will overwrite by customer's model_fn but self.initialized = False
https://github.com/aws/sagemaker-huggingface-inference-toolkit/blob/main/src/sagemaker_huggingface_inference_toolkit/handler_service.py#L85-L89

Then when customer send the first request, self.initialize() will get called again https://github.com/aws/sagemaker-huggingface-inference-toolkit/blob/main/src/sagemaker_huggingface_inference_toolkit/handler_service.py#L248. Since self.model is the same as model_fn, we will always pass in context.

*Description of changes:*

Add warning message for future debug

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
