### PR TITLE
fix(setup): install either tensorflow-macos or tensorflow depending on platform processor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 import os
 from datetime import date
 from setuptools import find_packages, setup
+import sys
 
 # We don't declare our dependency on transformers here because we build with
 # different packages for different variants
@@ -61,7 +62,15 @@ extras["diffusers"] = ["diffusers>=0.23.0"]
 extras["torch"] = ["torch>=1.8.0", "torchaudio"]
 
 # TODO: Remove upper bound of TF 2.11 once transformers release contains this fix: https://github.com/huggingface/evaluate/pull/372
-extras["tensorflow"] = ["tensorflow>=2.4.0,<2.11"]
+if sys.platform == "darwin":
+    import platform
+    if platform.processor() == "arm":
+        tensorflow_versions = ["tensorflow-macos>=2.4.0,<2.11"]
+    else:
+        tensorflow_versions = ["tensorflow>=2.4.0,<2.11"]
+    extras["tensorflow"] = tensorflow_versions
+else:
+    extras["tensorflow"] = ["tensorflow>=2.4.0,<2.11"]
 
 # MMS Server dependencies
 extras["mms"] = ["multi-model-server>=1.1.4", "retrying"]


### PR DESCRIPTION
*Issue #, if available:*

I have a M1 Mac and unable to install the dependencies for development using the provided command in the `README` which is `pip install -e ".[test,dev]"`

Error gotten:

```
ERROR: Could not find a version that satisfies the requirement tensorflow<2.11,>=2.4.0; extra == "dev" (from sagemaker-huggingface-inference-toolkit[dev,test]) (from versions: 2.13.0rc0, 2.13.0rc1, 2.13.0rc2, 2.13.0, 2.13.1, 2.14.0rc0, 2.14.0rc1, 2.14.0, 2.14.1, 2.15.0rc0, 2.15.0rc1, 2.15.0, 2.15.1, 2.16.0rc0, 2.16.1)
ERROR: No matching distribution found for tensorflow<2.11,>=2.4.0; extra == "dev"
```

Python version: `3.9.1`

*Description of changes:*

Found a solution suggested by Apple [here](https://developer.apple.com/metal/tensorflow-plugin/) where for TF versions `<= 2.12` we should install `tensorflow-macos` instead. Checking `sys.platform == "darwin"` and `platform.processor() == "arm"` seems to have fixed the problem for me

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
