### PR TITLE
feat(initialize): default to first GPU when gpu_id not provided

### DIFF
--- a/src/sagemaker_huggingface_inference_toolkit/handler_service.py
+++ b/src/sagemaker_huggingface_inference_toolkit/handler_service.py
@@ -99,7 +99,10 @@ class HuggingFaceHandlerService(ABC):
         The get device function will return the device for the DL Framework.
         """
         if _is_gpu_available():
-            return int(self.context.system_properties.get("gpu_id"))
+            # there may be cases when gpu_id isn't provided, in which case
+            # then we default to the first GPU
+            gpu_id = self.context.system_properties.get('gpu_id') or 0
+            return int(gpu_id)
         else:
             return -1
 


### PR DESCRIPTION
*Issue #, if available:*

I was trying to deploy Huggingface Transformers on Sagemaker with multi-modal-server (MMS) `preload_model = true` (about [preloading](https://github.com/awslabs/multi-model-server/blob/master/docs/configuration.md#preloading-a-model)). Unfortunately I hit a snag and the server was unable to preload the model due to missing GPU ID

<img width="1298" alt="Screenshot 2024-05-31 at 4 09 14 PM" src="https://github.com/aws/sagemaker-huggingface-inference-toolkit/assets/10100624/8c8cd8fc-cc6f-4d47-853e-33462794914c">

Checking the MMS code [here](https://github.com/awslabs/multi-model-server/blob/2b8930070a4093555813a9fb28185b2c098da7ec/mms/model_service_worker.py#L100), [here](https://github.com/awslabs/multi-model-server/blob/706aa9c755576e4d8122514358649a0edfbc8992/mms/model_service_worker.py#L239), and [here](https://github.com/awslabs/multi-model-server/blob/2b8930070a4093555813a9fb28185b2c098da7ec/mms/model_service_worker.py#L206) we can see that no GPU ID is provided on model preload. Worse, the `service` will be constructed with no GPU ID and thus on subsequent attempts to initialize on prediction in the [handler](https://github.com/aws/sagemaker-huggingface-inference-toolkit/blob/5da763a7edc6b414f726b678ec2099be2a530b76/src/sagemaker_huggingface_inference_toolkit/handler_service.py#L247), the same exception will again be raised

<img width="1112" alt="Screenshot 2024-05-31 at 4 20 49 PM" src="https://github.com/aws/sagemaker-huggingface-inference-toolkit/assets/10100624/66870f86-0874-4c99-a978-3ac6ffacb877">

Considering that the existing call already uses `.get` instead of indexing operator, arguable there was already awareness that `gpu_id` may be missing, but it was not properly handled. Or it was thought that in subsequent initialization attempts the problem will be fixed

*Description of changes:*

Provide a default GPU ID of 0, if no `gpu_id` is provided, indicating downstream code to use the first GPU. I feel like this solution is quite sensible considering that we already check whether GPU is available or not and thus, we should be safe to assume that there is at least 1 GPU with GPU ID 0. Though I'm not entirely well-versed in GPU ID schemes so maybe 0 isn't a universally applicable ID to use

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
